### PR TITLE
Fixed the styles example to request GL 3.2 context

### DIFF
--- a/examples/styles.rs
+++ b/examples/styles.rs
@@ -5,7 +5,7 @@ extern crate gfx_text;
 
 use gfx::traits::{IntoCanvas, Stream};
 use gfx_window_glutin as gfxw;
-use glutin::{WindowBuilder, Event, VirtualKeyCode};
+use glutin::{WindowBuilder, Event, VirtualKeyCode, GL_CORE};
 
 const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 const BROWN: [f32; 4] = [0.65, 0.16, 0.16, 1.0];
@@ -18,6 +18,7 @@ fn main() {
         let window = WindowBuilder::new()
             .with_dimensions(640, 480)
             .with_title(format!("gfx_text example"))
+            .with_gl(GL_CORE)
             .build()
             .unwrap();
         gfxw::init(window).into_canvas()


### PR DESCRIPTION
Was getting the following error without this:

> thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ProgramError(Vertex(ShaderCompilationFailed("0:2(10): error: GLSL 1.50 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.00 ES, and 3.00 ES\n")))', /home/rustbuild/src/rust-buildbot/slave/beta-dist-rustc-linux/build/src/libcore/result.rs:729
