### PR TITLE
Lower requirements to GLSL 1.3

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,7 +598,7 @@ mod shader_structs {
 use shader_structs::{Vertex, ShaderParams};
 
 const VERTEX_SRC: &'static [u8] = b"
-    #version 150 core
+    #version 130
 
     in vec2 a_Pos;
     in vec4 a_Color;
@@ -631,7 +631,7 @@ const VERTEX_SRC: &'static [u8] = b"
 ";
 
 const FRAGMENT_SRC: &'static [u8] = b"
-    #version 150 core
+    #version 130
 
     in vec4 v_Color;
     in vec2 v_TexCoord;


### PR DESCRIPTION
I've got this Debian stable (8.3) installation on a laptop with integrated graphics and an i915 driver. I'm unable to use the current gfx_text because its shaders require GLSL 1.50. By simply lowering the version requirement in the shader headers to GLSL 1.30 I'm able to run the gfx_text styles example on my laptop. Unless there's a good reason why the requirement should be at 1.50, please accept this PR. I bet there are lots of people like me with non-monster computers.
