### PR TITLE
Update to gfx 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_text"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Kagami Hiiragi <kagami@genshiken.org>"]
 description = "Draw text for gfx using freetype."
 keywords = ["gfx", "graphics", "text", "freetype", "font"]
@@ -11,7 +11,7 @@ repository = "https://github.com/PistonDevelopers/gfx_text.git"
 documentation = "http://docs.piston.rs/gfx_text/gfx_text/"
 
 [dependencies]
-gfx = "0.8"
+gfx = "0.9"
 freetype-rs = "0.5.0"
 
 [features]
@@ -21,7 +21,7 @@ include-font = []
 ### For examples
 
 [dev-dependencies]
-gfx_window_glutin = "0.8.0"
+gfx_window_glutin = "0.9.0"
 glutin = "0.4"
 #log = "*"
 #env_logger = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_text"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Kagami Hiiragi <kagami@genshiken.org>"]
 description = "Draw text for gfx using freetype."
 keywords = ["gfx", "graphics", "text", "freetype", "font"]
@@ -11,7 +11,7 @@ repository = "https://github.com/PistonDevelopers/gfx_text.git"
 documentation = "http://docs.piston.rs/gfx_text/gfx_text/"
 
 [dependencies]
-gfx = "0.9"
+gfx = "~0.9.1"
 freetype-rs = "0.5.0"
 
 [features]
@@ -21,7 +21,7 @@ include-font = []
 ### For examples
 
 [dev-dependencies]
-gfx_window_glutin = "0.9.0"
+gfx_window_glutin = "~0.9.1"
 glutin = "0.4"
 #log = "*"
 #env_logger = "*"

--- a/examples/styles.rs
+++ b/examples/styles.rs
@@ -23,7 +23,7 @@ fn main() {
             .with_dimensions(640, 480)
             .with_title(format!("gfx_text example"))
             .with_gl(GL_CORE);
-        gfxw::init::<gfx::format::Rgba8>(builder)
+        gfxw::init::<gfx::format::Rgba8, gfx::format::Depth>(builder)
     };
     let mut encoder = factory.create_encoder();
 

--- a/examples/styles.rs
+++ b/examples/styles.rs
@@ -4,7 +4,7 @@ extern crate gfx_window_glutin;
 extern crate glutin;
 extern crate gfx_text;
 
-use gfx::traits::Stream;
+use gfx::traits::{Device, FactoryExt};
 use gfx_window_glutin as gfxw;
 use gfx_text::{HorizontalAnchor, VerticalAnchor};
 use glutin::{WindowBuilder, Event, VirtualKeyCode, GL_CORE};
@@ -18,15 +18,14 @@ const FONT_PATH: &'static str = "examples/assets/Ubuntu-R.ttf";
 fn main() {
     // env_logger::init().unwrap();
 
-    let (mut stream, mut device, factory) = {
-        let window = WindowBuilder::new()
+    let (window, mut device, mut factory, main_color, _) = {
+        let builder = WindowBuilder::new()
             .with_dimensions(640, 480)
             .with_title(format!("gfx_text example"))
-            .with_gl(GL_CORE)
-            .build()
-            .unwrap();
-        gfxw::init(window)
+            .with_gl(GL_CORE);
+        gfxw::init::<gfx::format::Rgba8>(builder)
     };
+    let mut encoder = factory.create_encoder();
 
     let mut normal_text = gfx_text::new(factory.clone()).unwrap();
     let mut big_text = gfx_text::new(factory.clone()).with_size(20).unwrap();
@@ -35,28 +34,38 @@ fn main() {
         .with_font(FONT_PATH)
         .unwrap();
 
+    let mut counter: u32 = 0;
+
     'main: loop {
-        for event in stream.out.window.poll_events() {
+        for event in window.poll_events() {
             match event {
                 Event::Closed => break 'main,
                 Event::KeyboardInput(_, _, Some(VirtualKeyCode::Escape)) => break 'main,
                 _ => {},
             }
         }
-        stream.clear(gfx::ClearData {color: WHITE, depth: 1.0, stencil: 0});
+
+        counter += 1;
 
         normal_text.add("The quick brown fox jumps over the lazy dog", [10, 10], BROWN);
         normal_text.add("The quick red fox jumps over the lazy dog", [30, 30], RED);
         normal_text.add_anchored("hello centred world", [320, 240], HorizontalAnchor::Center, VerticalAnchor::Center, BLUE);
-        normal_text.draw(&mut stream).unwrap();
+        normal_text.add_anchored(&format!("Count: {}", counter), [0, 479], HorizontalAnchor::Left, VerticalAnchor::Bottom, BLUE);
 
         big_text.add("The big brown fox jumps over the lazy dog", [50, 50], BROWN);
-        big_text.draw(&mut stream).unwrap();
 
         custom_font_text.add("The custom blue fox jumps over the lazy dog", [10, 80], BLUE);
         custom_font_text.add_anchored("I live in the bottom right", [639, 479], HorizontalAnchor::Right, VerticalAnchor::Bottom, RED);
-        custom_font_text.draw(&mut stream).unwrap();
 
-        stream.present(&mut device);
+        encoder.reset();
+        encoder.clear(&main_color, WHITE);
+
+        normal_text.draw(&mut encoder, main_color.clone()).unwrap();
+        big_text.draw(&mut encoder, main_color.clone()).unwrap();
+        custom_font_text.draw(&mut encoder, main_color.clone()).unwrap();
+
+        device.submit(encoder.as_buffer());
+        window.swap_buffers().unwrap();
+        device.cleanup();
     }
 }

--- a/examples/styles.rs
+++ b/examples/styles.rs
@@ -60,9 +60,9 @@ fn main() {
         encoder.reset();
         encoder.clear(&main_color, WHITE);
 
-        normal_text.draw(&mut encoder, main_color.clone()).unwrap();
-        big_text.draw(&mut encoder, main_color.clone()).unwrap();
-        custom_font_text.draw(&mut encoder, main_color.clone()).unwrap();
+        normal_text.draw(&mut encoder, &main_color).unwrap();
+        big_text.draw(&mut encoder, &main_color).unwrap();
+        custom_font_text.draw(&mut encoder, &main_color).unwrap();
 
         device.submit(encoder.as_buffer());
         window.swap_buffers().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,10 +440,8 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
             vbuf: self.vertex_buffer.clone(),
             proj: proj,
             screen_size: {
-                // TODO: Is there a public interface to find a RenderTargetView's size?
-                //let (w, h) = target.raw().get_dimensions();
-                //[w as f32, h as f32]
-                [640.0, 480.0] // TODO: FIXTHIS
+                let (w, h, _, _) = target.get_dimensions();
+                [w as f32, h as f32]
             },
             color: self.color.clone(),
             out_color: target.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,12 +33,11 @@ extern crate freetype;
 
 use std::cmp::max;
 use std::marker::PhantomData;
-use gfx::{Factory, Resources, PrimitiveType, ProgramError, DrawError, UpdateError};
-use gfx::traits::{FactoryExt, Output, Stream, ToIndexSlice, ToSlice};
-use gfx::handle::{Program, Buffer, Texture};
-use gfx::batch::Full as FullBatch;
-use gfx::batch::Error as BatchError;
-use gfx::tex::{self, TextureError};
+use gfx::{CommandBuffer, Encoder, Factory, Resources, UpdateError};
+use gfx::handle::{Buffer, RenderTargetView};
+use gfx::pso::PipelineState;
+use gfx::tex;
+use gfx::traits::FactoryExt;
 mod font;
 use font::BitmapFont;
 pub use font::FontError;
@@ -63,16 +62,10 @@ const DEFAULT_FONT_DATA: Option<&'static [u8]> =
 /// General error type returned by the library. Wraps all other errors.
 #[derive(Debug)]
 pub enum Error {
-    /// Program linking error
-    ProgramError(ProgramError),
     /// Font loading error
     FontError(FontError),
-    /// Texture creation/updation error
-    TextureError(TextureError),
-    /// Draw-time error
-    DrawError(DrawError<BatchError>),
-    /// An error occuring at batch creation
-    BatchError(BatchError),
+    /// Texture creation/update error
+    TextureError(tex::Error),
     /// An error occuring in buffer/texture updates
     UpdateError(UpdateError<usize>),
 }
@@ -99,24 +92,12 @@ pub enum VerticalAnchor {
     Bottom,
 }
 
-impl From<ProgramError> for Error {
-    fn from(e: ProgramError) -> Error { Error::ProgramError(e) }
-}
-
 impl From<FontError> for Error {
     fn from(e: FontError) -> Error { Error::FontError(e) }
 }
 
-impl From<TextureError> for Error {
-    fn from(e: TextureError) -> Error { Error::TextureError(e) }
-}
-
-impl From<DrawError<BatchError>> for Error {
-    fn from(e: DrawError<BatchError>) -> Error { Error::DrawError(e) }
-}
-
-impl From<BatchError> for Error {
-    fn from(e: BatchError) -> Error { Error::BatchError(e) }
+impl From<tex::Error> for Error {
+    fn from(e: tex::Error) -> Error { Error::TextureError(e) }
 }
 
 impl From<UpdateError<usize>> for Error {
@@ -127,15 +108,14 @@ type IndexT = u32;
 
 /// Text renderer.
 pub struct Renderer<R: Resources, F: Factory<R>> {
-    factory: F,
-    program: Program<R>,
-    draw_state: gfx::DrawState,
+    factory: F, // TODO: Can we avoid hanging on to this?
+    pso: PipelineState<R, pipe::Meta>,
     vertex_data: Vec<Vertex>,
     vertex_buffer: Buffer<R, Vertex>,
     index_data: Vec<IndexT>,
     index_buffer: Buffer<R, IndexT>,
     font_bitmap: BitmapFont,
-    params: ShaderParams<R>,
+    color: (gfx::handle::ShaderResourceView<R, f32>, gfx::handle::Sampler<R>),
 }
 
 /// Text renderer builder. Allows to set rendering options using builder
@@ -233,8 +213,6 @@ impl<'r, R: Resources, F: Factory<R>> RendererBuilder<'r, R, F> {
 
     /// Build a new text renderer instance using current settings.
     pub fn build(mut self) -> Result<Renderer<R, F>, Error> {
-        let program = try!(self.factory.link_program(VERTEX_SRC, FRAGMENT_SRC));
-        let state = gfx::DrawState::new().blend(gfx::BlendPreset::Alpha);
         let vertex_buffer = self.factory.create_buffer_dynamic(
             self.buffer_size,
             gfx::BufferRole::Vertex,
@@ -267,21 +245,22 @@ impl<'r, R: Resources, F: Factory<R>> RendererBuilder<'r, R, F> {
                                   tex::WrapMode::Clamp)
         );
 
+        let pso = self.factory.create_pipeline_simple(
+            VERTEX_SRC,
+            FRAGMENT_SRC,
+            gfx::state::CullFace::Back,
+            pipe::new()
+        ).unwrap(); // TODO: Handle Error
+
         Ok(Renderer {
             factory: self.factory,
-            program: program,
-            draw_state: state,
+            pso: pso,
             vertex_data: Vec::new(),
             vertex_buffer: vertex_buffer,
             index_data: Vec::new(),
             index_buffer: index_buffer,
             font_bitmap: font_bitmap,
-            params: ShaderParams {
-                color: (font_texture, Some(sampler)),
-                screen_size: [0.0, 0.0],
-                proj: DEFAULT_PROJECTION,
-                _r: PhantomData,
-            },
+            color: (font_texture, sampler),
         })
     }
 
@@ -407,10 +386,10 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
     /// ```ignore
     /// text.add("Test1", [10, 10], [1.0, 0.0, 0.0, 1.0]);
     /// text.add("Test2", [20, 20], [0.0, 1.0, 0.0, 1.0]);
-    /// text.draw(&mut stream);
+    /// text.draw(&mut encoder, color_output.clone()).unwrap();
     /// ```
-    pub fn draw<S: Stream<R>>(&mut self, stream: &mut S) -> Result<(), Error> {
-        self.draw_at(stream, DEFAULT_PROJECTION)
+    pub fn draw<C: CommandBuffer<R>>(&mut self, encoder: &mut Encoder<R, C>, target: RenderTargetView<R, gfx::format::Rgba8>) -> Result<(), Error> {
+        self.draw_at(encoder, target, DEFAULT_PROJECTION)
     }
 
     /// Draw using provided projection matrix.
@@ -420,11 +399,12 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
     /// ```ignore
     /// text.add_at("Test1", [6.0, 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]);
     /// text.add_at("Test2", [0.0, 5.0, 0.0], [0.0, 1.0, 0.0, 1.0]);
-    /// text.draw_at(&mut stream, camera_projection);
+    /// text.draw_at(&mut encoder, color_output.clone(), camera_projection).unwrap();
     /// ```
-    pub fn draw_at<S: Stream<R>>(
+    pub fn draw_at<C: CommandBuffer<R>>(
         &mut self,
-        stream: &mut S,
+        encoder: &mut Encoder<R, C>,
+        target: RenderTargetView<R, gfx::format::Rgba8>,
         proj: [[f32; 4]; 4]
     ) -> Result<(), Error> {
         let ver_len = self.vertex_data.len();
@@ -442,74 +422,33 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
             let len = grow_buffer_size(ind_buf_len, ind_len);
             self.index_buffer = self.factory.create_buffer_dynamic(len, gfx::BufferRole::Index);
         }
-        // Move vertex/index data.
-        {
-            let renderer = stream.access().0;
-            try!(renderer.update_buffer(self.vertex_buffer.raw(), &self.vertex_data, 0));
-            try!(renderer.update_buffer(self.index_buffer.raw(), &self.index_data, 0));
-        }
-        let nv = self.vertex_data.len() as gfx::VertexCount;
-        let ni = self.index_data.len() as gfx::VertexCount;
+        //try!(encoder.update_buffer(&self.vertex_buffer, &self.vertex_data, 0));
+        //try!(encoder.update_buffer(&self.index_buffer, &self.index_data, 0));
+        //let nv = self.vertex_data.len() as gfx::VertexCount;
+        //let ni = self.index_data.len() as gfx::VertexCount;
+
+        // TODO: DONT USE THIS, update the buffer as above instead
+        let (vbuf, slice) = self.factory.create_vertex_buffer_indexed(&self.vertex_data, &self.index_data[..]);
+
+        let data = pipe::Data {
+            vbuf: vbuf,
+            proj: proj,
+            screen_size: {
+                // TODO: Is there a public interface to find a RenderTargetView's size?
+                //let (w, h) = target.raw().get_dimensions();
+                //[w as f32, h as f32]
+                [640.0, 480.0] // TODO: FIXTHIS
+            },
+            color: self.color.clone(),
+            out_color: target,
+        };
 
         // Clear state.
         self.vertex_data.clear();
         self.index_data.clear();
 
-        let mesh = gfx::Mesh::from_format(self.vertex_buffer.clone(), nv);
-        let mut slice = self.index_buffer.to_slice(PrimitiveType::TriangleList);
-        slice.end = ni;
-        self.params.screen_size = {
-            let (w, h) = stream.get_output().get_size();
-            [w as f32, h as f32]
-        };
-        self.params.proj = proj;
-        let batch = gfx::batch::bind(
-            &self.draw_state,
-            &mesh,
-            slice,
-            &self.program,
-            &self.params);
-
-        Ok(try!(stream.draw(&batch)))
-    }
-
-    /// Former resulting batch.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let batch = text.get_batch(stream.get_output());
-    /// stream.draw(&batch);
-    /// ```
-    pub fn get_batch<O: Output<R>>(&mut self, output: &O)
-                     -> Result<FullBatch<ShaderParams<R>>, Error> {
-        self.get_batch_at(output, DEFAULT_PROJECTION)
-    }
-
-    /// Former batch for the given projection matrix.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let batch = text.get_batch_at(stream.get_output(), camera_projection);
-    /// stream.draw(&batch);
-    /// ```
-    pub fn get_batch_at<O: Output<R>>(&mut self, output: &O, proj: [[f32; 4]; 4])
-                        -> Result<FullBatch<ShaderParams<R>>, Error> {
-        let mesh = self.factory.create_mesh(&self.vertex_data);
-        let slice = self.index_data.to_slice(&mut self.factory,
-                                             PrimitiveType::TriangleList);
-        self.vertex_data.clear();
-        self.index_data.clear();
-        self.params.screen_size = {
-            let (w, h) = output.get_size();
-            [w as f32, h as f32]
-        };
-        self.params.proj = proj;
-        let mut batch = try!(FullBatch::new(mesh, self.program.clone(),
-                                            self.params.clone()));
-        batch.slice = slice;
-        Ok(batch)
+        encoder.draw(&slice, &self.pso, &data);
+        Ok(())
     }
 
     // TODO: Currently reports height based on the tallest glyph in the string.
@@ -558,44 +497,36 @@ fn create_texture_r8_static<R: Resources, F: Factory<R>>(
     width: u16,
     height: u16,
     data: &[u8],
-) -> Result<Texture<R>, TextureError> {
-    let texture = try!(factory.create_texture(tex::TextureInfo {
-        width: width,
-        height: height,
-        depth: 1,
-        levels: 1,
-        kind: tex::Kind::D2,
-        format: tex::R8,
-    }));
-    try!(factory.update_texture_raw(
-        &texture,
-        &(*texture.get_info()).into(),
-        data,
-        None,
-    ));
-    Ok(texture)
+) -> Result<gfx::handle::ShaderResourceView<R, f32>, tex::Error> {
+    let kind = tex::Kind::D2(width, height, tex::AaMode::Single);
+    match factory.create_texture_const::<(gfx::format::R8, gfx::format::Unorm)>(kind, gfx::cast_slice(&data), false) {
+        Ok((_, texture_view)) => Ok(texture_view),
+        // TODO: Actually determine the error, gfx returns a type which is not publiclly exported here,
+        //       so there's no way to find what actually went wrong.
+        Err(_) => Err(tex::Error::Kind),
+    }
 }
 
 // Hack to hide shader structs from the library user.
 mod shader_structs {
-    use gfx::shade::TextureParam;
-
-    gfx_vertex!( Vertex {
-        a_Pos@ pos: [f32; 2],
-        a_TexCoord@ tex: [f32; 2],
-        a_World_Pos@ world_pos: [f32; 3],
+    gfx_vertex_struct!( Vertex {
+        pos: [f32; 2] = "a_Pos",
+        color: [f32; 4] = "a_Color",
+        tex: [f32; 2] = "a_TexCoord",
+        world_pos: [f32; 3] = "a_World_Pos",
         // Should be bool but gfx-rs doesn't support it.
-        a_Screen_Rel@ screen_rel: i32,
-        a_Color@ color: [f32; 4],
+        screen_rel: i32 = "a_Screen_Rel",
     });
 
-    gfx_parameters!( ShaderParams {
-        t_Color@ color: TextureParam<R>,
-        u_Screen_Size@ screen_size: [f32; 2],
-        u_Proj@ proj: [[f32; 4]; 4],
+    gfx_pipeline!( pipe {
+        vbuf: gfx::VertexBuffer<Vertex> = (),
+        screen_size: gfx::Global<[f32; 2]> = "u_Screen_Size",
+        proj: gfx::Global<[[f32; 4]; 4]> = "u_Proj",
+        color: gfx::TextureSampler<f32> = "t_Color",
+        out_color: gfx::BlendTarget<gfx::format::Rgba8> = ("o_Color", gfx::state::MASK_ALL, gfx::preset::blend::ALPHA),
     });
 }
-use shader_structs::{Vertex, ShaderParams};
+use shader_structs::{Vertex, pipe};
 
 const VERTEX_SRC: &'static [u8] = b"
     #version 150 core

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! );
 //!
 //! // Draw text.
-//! text.draw(&mut encoder, color_output.clone()).unwrap();
+//! text.draw(&mut encoder, &color_output).unwrap();
 //! ```
 
 #![deny(missing_docs)]
@@ -115,7 +115,7 @@ type IndexT = u32;
 
 /// Text renderer.
 pub struct Renderer<R: Resources, F: Factory<R>> {
-    factory: F, // TODO: Can we avoid hanging on to this?
+    factory: F,
     pso: PipelineState<R, pipe::Meta>,
     vertex_data: Vec<Vertex>,
     vertex_buffer: Buffer<R, Vertex>,
@@ -393,9 +393,9 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
     /// ```ignore
     /// text.add("Test1", [10, 10], [1.0, 0.0, 0.0, 1.0]);
     /// text.add("Test2", [20, 20], [0.0, 1.0, 0.0, 1.0]);
-    /// text.draw(&mut encoder, color_output.clone()).unwrap();
+    /// text.draw(&mut encoder, &color_output).unwrap();
     /// ```
-    pub fn draw<C: CommandBuffer<R>>(&mut self, encoder: &mut Encoder<R, C>, target: RenderTargetView<R, gfx::format::Rgba8>) -> Result<(), Error> {
+    pub fn draw<C: CommandBuffer<R>>(&mut self, encoder: &mut Encoder<R, C>, target: &RenderTargetView<R, gfx::format::Rgba8>) -> Result<(), Error> {
         self.draw_at(encoder, target, DEFAULT_PROJECTION)
     }
 
@@ -406,12 +406,12 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
     /// ```ignore
     /// text.add_at("Test1", [6.0, 0.0, 0.0], [1.0, 0.0, 0.0, 1.0]);
     /// text.add_at("Test2", [0.0, 5.0, 0.0], [0.0, 1.0, 0.0, 1.0]);
-    /// text.draw_at(&mut encoder, color_output.clone(), camera_projection).unwrap();
+    /// text.draw_at(&mut encoder, &color_output, camera_projection).unwrap();
     /// ```
     pub fn draw_at<C: CommandBuffer<R>>(
         &mut self,
         encoder: &mut Encoder<R, C>,
-        target: RenderTargetView<R, gfx::format::Rgba8>,
+        target: &RenderTargetView<R, gfx::format::Rgba8>,
         proj: [[f32; 4]; 4]
     ) -> Result<(), Error> {
         let ver_len = self.vertex_data.len();
@@ -446,7 +446,7 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
                 [640.0, 480.0] // TODO: FIXTHIS
             },
             color: self.color.clone(),
-            out_color: target,
+            out_color: target.clone(),
         };
 
         // Clear state.


### PR DESCRIPTION
Fixes #37

This isn't quite ready to merge yet, I think it's ok except for one issue - draw isn't generic over the RenderTargetView format, i.e if in example/style.rs you try to init with an Srgb8 output format it won't build.

I'm not sure what the right approach is here, paging @kvark, @sectopod
