### PR TITLE
Revert "Fix gfx build error (again)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gfx_text"
-version = "0.13.2"
+version = "0.13.1"
 authors = ["Kagami Hiiragi <kagami@genshiken.org>"]
 description = "Draw text for gfx using freetype."
 keywords = ["gfx", "graphics", "text", "freetype", "font"]
@@ -11,7 +11,7 @@ repository = "https://github.com/PistonDevelopers/gfx_text.git"
 documentation = "http://docs.piston.rs/gfx_text/gfx_text/"
 
 [dependencies]
-gfx = "0.12.2"
+gfx = "0.12"
 freetype-rs = "0.11"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,8 +555,6 @@ fn create_texture_r8_static<R: Resources, F: Factory<R>>(
 
 // Hack to hide shader structs from the library user.
 mod shader_structs {
-    extern crate gfx;
-
     gfx_vertex_struct!( Vertex {
         pos: [f32; 2] = "a_Pos",
         tex: [f32; 2] = "a_TexCoord",


### PR DESCRIPTION
Reverts PistonDevelopers/gfx_text#51

gfx 0.12.2 has been yanked. See https://github.com/gfx-rs/gfx/issues/1070#issuecomment-258179212