### PR TITLE
Fix measuring text height

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -16,6 +16,7 @@ pub struct BitmapFont {
     height: u16,
     chars: HashMap<char, BitmapChar>,
     image: Vec<u8>,
+    font_height: u16,
 }
 
 #[derive(Debug)]
@@ -277,6 +278,7 @@ impl BitmapFont {
             height: image_height as u16,
             chars: chars_info,
             image: image,
+            font_height: (face.size_metrics().unwrap().height >> 6) as u16,
         })
     }
 
@@ -291,6 +293,10 @@ impl BitmapFont {
     /// Return 8-bit texture raw data (grayscale).
     pub fn get_image(&self) -> &[u8] {
         &self.image
+    }
+
+    pub fn get_font_height(&self) -> u16 {
+        self.font_height
     }
 
     pub fn find_char(&self, ch: char) -> Option<&BitmapChar> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@
 extern crate gfx;
 extern crate freetype;
 
-use std::cmp::max;
 use std::collections::hash_map::{Entry, HashMap};
 use std::marker::PhantomData;
 use gfx::{CombinedError, CommandBuffer, Encoder, Factory, PipelineStateError, Resources, UpdateError};
@@ -505,13 +504,9 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
         Ok(())
     }
 
-    // TODO: Currently reports height based on the tallest glyph in the string.
-    // It might be more useful to go by the tallest in the whole font to avoid
-    // text jumping around as it changes.
     /// Get the bounding box size of a string as rendered by this font.
     pub fn measure(&self, text: &str) -> (i32, i32) {
         let mut width = 0;
-        let mut height = 0;
         let mut last_char = None;
 
         for ch in text.chars() {
@@ -522,7 +517,6 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
             last_char = Some(ch_info);
 
             width += ch_info.x_advance;
-            height = max(height, ch_info.y_offset + ch_info.height);
         }
 
         match last_char {
@@ -530,7 +524,7 @@ impl<R: Resources, F: Factory<R>> Renderer<R, F> {
             None => (),
         }
 
-        (width, height)
+        (width, self.font_bitmap.get_font_height() as i32)
     }
 }
 


### PR DESCRIPTION
This is a change that was already mentioned as "todo" in measure function's comment. Height returned from measure() function is always font's height in pixel.

It's taken from font size metrics so it gives better result than suggested max of all glyphs height as it also includes nice bottom margin (similar to top margin from bitmap_top). Drawing box from returned values gives a nice rounding box.