### PR TITLE
Rewrote "examples/styles" to use piston_window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include-font = []
 ### For examples
 
 [dev-dependencies]
-gfx_window_glutin = "0.31.0"
-glutin = "0.21.0"
+piston_window = "0.123.0"
+
 #log = "*"
 #env_logger = "*"

--- a/examples/styles.rs
+++ b/examples/styles.rs
@@ -1,17 +1,8 @@
-// extern crate env_logger;
-extern crate gfx;
-extern crate gfx_window_glutin;
-extern crate glutin;
+extern crate piston_window;
 extern crate gfx_text;
 
-use gfx::Device;
-use gfx_window_glutin as gfxw;
+use piston_window::*;
 use gfx_text::{HorizontalAnchor, VerticalAnchor};
-use glutin::{
-    WindowBuilder, Event, VirtualKeyCode,
-    WindowEvent, KeyboardInput, EventsLoop,
-    GL_CORE
-};
 
 const WHITE: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
 const BROWN: [f32; 4] = [0.65, 0.16, 0.16, 1.0];
@@ -20,78 +11,51 @@ const BLUE: [f32; 4] = [0.0, 0.0, 1.0, 1.0];
 const FONT_PATH: &'static str = "examples/assets/Ubuntu-R.ttf";
 
 fn main() {
-    // env_logger::init().unwrap();
+    let title = "gfx_text example";
+    let mut window: PistonWindow = WindowSettings::new(title, [640, 480])
+        .exit_on_esc(true)
+        .build()
+        .unwrap_or_else(|e| panic!("Failed to build PistonWindow: {}", e));
 
-    let mut events_loop = EventsLoop::new();
-    let context = glutin::ContextBuilder::new()
-        .with_gl(GL_CORE);
-    let (window, mut device, mut factory, main_color, _) = {
-        let builder = WindowBuilder::new()
-            .with_dimensions((640, 480).into())
-            .with_title(format!("gfx_text example"));
-        gfxw::init::<gfx::format::Rgba8, gfx::format::Depth>(builder, context, &events_loop).unwrap()
-    };
-    let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
+    let mut encoder: GfxEncoder = window.factory.create_command_buffer().into();
 
-    let mut normal_text = gfx_text::new(factory.clone()).unwrap();
-    let mut big_text = gfx_text::new(factory.clone()).with_size(20).unwrap();
-    let mut custom_font_text = gfx_text::new(factory.clone())
-        .with_size(25)
+    let hdpi = window.draw_size().width / window.size().width;
+
+    let mut normal_text = gfx_text::new(window.factory.clone())
+        .with_size((16.0 * hdpi) as u8).unwrap();
+    let mut big_text = gfx_text::new(window.factory.clone())
+        .with_size((20.0 * hdpi) as u8).unwrap();
+    let mut custom_font_text = gfx_text::new(window.factory.clone())
+        .with_size((25.0 * hdpi) as u8)
         .with_font(FONT_PATH)
         .unwrap();
 
+    let main_color = window.output_color.clone();
     let mut counter: u32 = 0;
-    let mut exit = false;
 
-    'main: loop {
-        events_loop.poll_events(|event| {
-            match event {
-                Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
-                    ..
-                } => {
-                    exit = true;
-                    return;
-                }
-                Event::WindowEvent {
-                    event: WindowEvent::KeyboardInput {
-                        input: KeyboardInput {
-                            virtual_keycode: Some(VirtualKeyCode::Escape),
-                            ..
-                        },
-                        ..
-                    },
-                    ..
-                } => {
-                    exit = true;
-                    return;
-                }
-                _ => {},
-            }
+    while let Some(e) = window.next() {
+        window.draw_3d(&e, |window| {
+            let pos = |p: [i32; 2]| [(p[0] as f64 * hdpi) as i32, (p[1] as f64 * hdpi) as i32];
+
+            encoder.clear(&main_color, WHITE);
+
+            counter += 1;
+
+            normal_text.add("The quick brown fox jumps over the lazy dog", pos([10, 10]), BROWN);
+            normal_text.add("The quick red fox jumps over the lazy dog", pos([30, 30]), RED);
+            normal_text.add_anchored("hello centred world", pos([320, 240]), HorizontalAnchor::Center, VerticalAnchor::Center, BLUE);
+            normal_text.add_anchored(&format!("Count: {}", counter), pos([0, 479]), HorizontalAnchor::Left, VerticalAnchor::Bottom, BLUE);
+
+            big_text.add("The big brown fox jumps over the lazy dog", pos([50, 50]), BROWN);
+
+            custom_font_text.add("The custom blue fox jumps over the lazy dog", pos([10, 80]), BLUE);
+            custom_font_text.add_anchored("I live in the bottom right", pos([639, 479]), HorizontalAnchor::Right, VerticalAnchor::Bottom, RED);
+
+            normal_text.draw(&mut encoder, &main_color).unwrap();
+            big_text.draw(&mut encoder, &main_color).unwrap();
+            custom_font_text.draw(&mut encoder, &main_color).unwrap();
+
+            encoder.flush(&mut window.device);
         });
-
-        if exit {break 'main;}
-
-        counter += 1;
-
-        normal_text.add("The quick brown fox jumps over the lazy dog", [10, 10], BROWN);
-        normal_text.add("The quick red fox jumps over the lazy dog", [30, 30], RED);
-        normal_text.add_anchored("hello centred world", [320, 240], HorizontalAnchor::Center, VerticalAnchor::Center, BLUE);
-        normal_text.add_anchored(&format!("Count: {}", counter), [0, 479], HorizontalAnchor::Left, VerticalAnchor::Bottom, BLUE);
-
-        big_text.add("The big brown fox jumps over the lazy dog", [50, 50], BROWN);
-
-        custom_font_text.add("The custom blue fox jumps over the lazy dog", [10, 80], BLUE);
-        custom_font_text.add_anchored("I live in the bottom right", [639, 479], HorizontalAnchor::Right, VerticalAnchor::Bottom, RED);
-
-        encoder.clear(&main_color, WHITE);
-
-        normal_text.draw(&mut encoder, &main_color).unwrap();
-        big_text.draw(&mut encoder, &main_color).unwrap();
-        custom_font_text.draw(&mut encoder, &main_color).unwrap();
-
-        encoder.flush(&mut device);
-        window.swap_buffers().unwrap();
-        device.cleanup();
     }
 }


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/gfx_text/issues/77

- Added support for retina screen